### PR TITLE
app-gen-toc.py: Convert pathlib object to string.

### DIFF
--- a/toolkit/app-gen-toc.py
+++ b/toolkit/app-gen-toc.py
@@ -630,7 +630,7 @@ def updateDeviceConfig(file):
                 unwanted_item = True
         if unwanted_item:
             print(
-                "[ERROR] File '" + file + "' should not contain 'miscellaneous' entry"
+                "[ERROR] File '" + file.as_posix() + "' should not contain 'miscellaneous' entry"
             )
             sys.exit(EXIT_WITH_ERROR)
     # Don't write out the json file, because it didn't change.


### PR DESCRIPTION
Fixes an error that's raised if the config has what seems to be invalid/obsolete entries.