### PR TITLE
tools: Pass device part number and rev as args.

### DIFF
--- a/toolkit/app-write-mram.py
+++ b/toolkit/app-write-mram.py
@@ -196,6 +196,10 @@ def main():
     parser.add_argument(
         "-V", "--version", help="Display Version Number", action="store_true"
     )
+    parser.add_argument("--cfg-part", type=str, help="Part Number")
+    parser.add_argument("--cfg-rev", type=str, help="Part Revision", default="B4")
+    parser.add_argument("--cfg-jtag", type=str, help="JTAG Interface", default="J-Link")
+    parser.add_argument("--cfg-mram", type=str, help="MRAM Interface", default="isp")
     parser.add_argument("-v", "--verbose", help="verbosity mode", action="store_true")
 
     args = parser.parse_args()
@@ -204,7 +208,7 @@ def main():
         sys.exit()
 
     # memory defines for Alif/OEM MRAM Addresses and Sizes
-    load_global_config()
+    load_global_config(args.cfg_part, args.cfg_rev, args.cfg_jtag, args.cfg_mram)
     DEVICE_PART_NUMBER = utils.config.DEVICE_PART_NUMBER
     DEVICE_REVISION = utils.config.DEVICE_REVISION
     DEVICE_REV_BAUD_RATE = utils.config.DEVICE_REV_BAUD_RATE

--- a/toolkit/maintenance.py
+++ b/toolkit/maintenance.py
@@ -742,6 +742,10 @@ def main():
     parser.add_argument(
         "-V", "--version", help="Display Version Number", action="store_true"
     )
+    parser.add_argument("--cfg-part", type=str, help="Part Number")
+    parser.add_argument("--cfg-rev", type=str, help="Part Revision", default="B4")
+    parser.add_argument("--cfg-jtag", type=str, help="JTAG Interface", default="J-Link")
+    parser.add_argument("--cfg-mram", type=str, help="MRAM Interface", default="isp")
     parser.add_argument("-v", "--verbose", help="verbosity mode", action="store_true")
     args = parser.parse_args()
     if args.version:
@@ -749,7 +753,7 @@ def main():
         sys.exit()
 
     # memory defines for Alif/OEM MRAM Addresses and Sizes
-    load_global_config()
+    load_global_config(args.cfg_part, args.cfg_rev, args.cfg_jtag, args.cfg_mram)
     ALIF_BASE_ADDRESS = utils.config.ALIF_BASE_ADDRESS
     OEM_BASE_ADDRESS = utils.config.APP_BASE_ADDRESS
     OEM_MRAM_SIZE = utils.config.APP_MRAM_SIZE

--- a/toolkit/updateSystemPackage.py
+++ b/toolkit/updateSystemPackage.py
@@ -112,6 +112,10 @@ def main():
     parser.add_argument(
         "-V", "--version", help="Display Version Number", action="store_true"
     )
+    parser.add_argument("--cfg-part", type=str, help="Part Number")
+    parser.add_argument("--cfg-rev", type=str, help="Part Revision", default="B4")
+    parser.add_argument("--cfg-jtag", type=str, help="JTAG Interface", default="J-Link")
+    parser.add_argument("--cfg-mram", type=str, help="MRAM Interface", default="isp")
     parser.add_argument("-v", "--verbose", help="verbosity mode", action="store_true")
     args = parser.parse_args()
     if args.version:
@@ -119,7 +123,7 @@ def main():
         sys.exit()
 
     # retrieve initial params based on user selection (toold-config)
-    load_global_config()
+    load_global_config(args.cfg_part, args.cfg_rev, args.cfg_jtag, args.cfg_mram)
     DEVICE_PART_NUMBER = utils.config.DEVICE_PART_NUMBER
     DEVICE_REVISION = utils.config.DEVICE_REVISION
     DEVICE_REV_BAUD_RATE = utils.config.DEVICE_REV_BAUD_RATE

--- a/toolkit/utils/config.py
+++ b/toolkit/utils/config.py
@@ -177,12 +177,21 @@ def load_device_config(devDescription, devRevision):
     APP_MRAM_SIZE = app_size
 
 
-def load_global_config():
+def load_global_config(part_num=None, part_rev=None, jtag_iface=None, mram_iface=None):
     global DEVICE_PART_NUMBER
     global DEVICE_REVISION
     global MRAM_BURN_INTERFACE
     global JTAG_ADAPTER
     global HASHES_DB
+
+    if part_num is not None:
+        DEVICE_PART_NUMBER = getPartDescription(part_num)
+        DEVICE_REVISION = part_rev
+        JTAG_ADAPTER = jtag_iface
+        MRAM_BURN_INTERFACE = mram_iface
+        HASHES_DB = read_global_config(HASHES_DB_FILE)
+        load_device_config(DEVICE_PART_NUMBER, DEVICE_REVISION)
+        return
 
     cfg = read_global_config(CONFIG_FILE)
 


### PR DESCRIPTION
Just a proof of concept.

The proposed fix here allows the following:
* Default behavior, load `global-cfg.db`
* Pass part/rev, which uses the same mechanisms to load the part info.

The part/rev can be set in `mpconfigboard.mk`, which is very consistent with other ports.