### PR TITLE
toolkit: validate arguments *after* modification is complete

### DIFF
--- a/toolkit/app-write-mram.py
+++ b/toolkit/app-write-mram.py
@@ -291,14 +291,11 @@ def main():
         argList = args.images
 
     if args.skip:
-        idx = argList.find("../build/AppTocPackage.bin 0x")
-        argList = argList[idx : idx + 37]
+        idx = argList.find("build/AppTocPackage.bin 0x")
+        argList = argList[idx : idx + 35]
 
     # validate all parameters
     argList = validateArgList(action, argList.strip(), args.pad)
-
-    if sys.platform == "linux" or sys.platform == "darwin":
-        argList = argList.replace("../", "")
 
     print("[INFO]", action + argList)
 
@@ -438,7 +435,6 @@ def main():
             addr = items[e]
             address = int(addr, base=16)
             fileName = items[e - 1]
-            fileName = fileName.replace("..\\", "")
 
             if (
                 burn_mram_isp(

--- a/toolkit/bin/application_package.ds
+++ b/toolkit/bin/application_package.ds
@@ -1,4 +1,4 @@
-set semihosting args ../build/AppTocPackage.bin 0x8057bf50
+set semihosting args build/AppTocPackage.bin 0x8057bf50
 continue
 wait
 reset reset.hardware


### PR DESCRIPTION
The current toolkit modifies path on MacOS and Linux platforms. Perform this validation only after the path is modified to allow the script to be run on Linux and MacOSX without error.

Before:
```
$ cd alif-security-toolkit/toolkit
$ python ./app-write-mram.py
Writing MRAM with parameters:
Device Part# B1 (AB1C1F4M51820PH) - 1.8 MRAM / 2.0 SRAM - Rev: A0
- Available MRAM: 1888256 bytes
<class 'FileNotFoundError'>
Error: there is a problem with the image ../build/AppTocPackage.bin
Please check it exists and retry
```

After:
```
$ cd alif-security-toolkit/toolkit
$ python ./app-write-mram.py
Writing MRAM with parameters:
Device Part# B1 (AB1C1F4M51820PH) - 1.8 MRAM / 2.0 SRAM - Rev: A0
- Available MRAM: 1888256 bytes
[INFO] Burning: build/AppTocPackage.bin 0x8057bf50
[INFO] baud rate  56500
[INFO] dynamic baud rate change  Enabled
[INFO] /dev/ttyACM0 open Serial port success
...
```

**P.S.:** Since we I benefit from this repo I try to contribute back... but we can silently maintain our own fork to avoid burdening MicroPython with extra Alif maintenance work.